### PR TITLE
SUMO-280958 Upgrade basic-ftp to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13827,9 +13827,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
-      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -47232,9 +47232,9 @@
       "dev": true
     },
     "basic-ftp": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
-      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true
     },
     "batch": {
@@ -50892,7 +50892,7 @@
       "integrity": "sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==",
       "dev": true,
       "requires": {
-        "basic-ftp": "^5.0.2",
+        "basic-ftp": "5.2.0",
         "data-uri-to-buffer": "^6.0.0",
         "debug": "^4.3.4",
         "fs-extra": "^8.1.0"

--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "examples/http",
     "examples/https",
     "examples/esm-http-ts"
-  ]
+  ],
+  "overrides": {
+    "basic-ftp": "5.2.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Added npm override to force basic-ftp version 5.2.0
- Updated package-lock.json with new basic-ftp version and integrity hash
- Updated get-uri requires section to reflect resolved version
